### PR TITLE
Reformat filenames & commands in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 I created this project to practice pulling data from an API, storing that data in a database, displaying the data in a pretty way, and creating a new API endpoint using the data. Through the project I also hope to provide a forum for others who want to learn about these topics or contribute to an open-source project for the first time. 
 
 ### Getting Started ###
-* pip install -r requirements.txt to make sure you have everything you need to run the program. Doing so in a virtual environment is recommended!
+* `pip install -r requirements.txt` to make sure you have everything you need to run the program. Doing so in a virtual environment is recommended!
 
-* Create a directory called secret with an empty __init__.py file inside. Make a key.py file in the secret directory (based on the secretkeys_template.py) and populate it with your Twitter API credentials.
+* Create a directory called secret with an empty `__init__.py` file inside. Make a `key.py` file in the secret directory (based on the `secretkeys_template.py`) and populate it with your Twitter API credentials.
 
 * I still need to create a seed file for the database for others to get up and running with the project. Stay tuned! 
 


### PR DESCRIPTION
Double underscore renders as bold in github's markdown. To fix, I used backticks around commands and filenames.