### PR TITLE
fixed typo in readme to 'keys.py'

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ I created this project to practice pulling data from an API, storing that data i
 ### Getting Started ###
 * `pip install -r requirements.txt` to make sure you have everything you need to run the program. Doing so in a virtual environment is recommended!
 
-* Create a directory called `secret` with an empty `__init__.py` file inside. Make a `key.py` file in the `secret` directory (based on the `secretkeys_template.py`) and populate it with your Twitter API credentials.
+* Create a directory called `secret` with an empty `__init__.py` file inside. Make a `keys.py` file in the `secret` directory (based on the `secretkeys_template.py`) and populate it with your Twitter API credentials.
 
 * I still need to create a seed file for the database for others to get up and running with the project. Stay tuned! 
 


### PR DESCRIPTION
Hi, just a small typo in the readme - I noticed this should be keys.py as your server.py file has `from secret import keys`