### PR TITLE
Create defaults and move overrides to environment variables

### DIFF
--- a/Create_Tweet_table.py
+++ b/Create_Tweet_table.py
@@ -1,8 +1,8 @@
 from sqlalchemy import create_engine
 from sqlalchemy import Table, Column, String, MetaData, Integer
+from server import DB_URI
 # modify the below postgresql address with you info
-db_string = "postgresql://username:password@localhost/newb"
-db = create_engine(db_string)
+db = create_engine(DB_URI)
 meta = MetaData(db)
 tweets_table = Table('tweets', meta,
                      Column('item_id', Integer, autoincrement=True, primary_key=True, nullable=False),

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ I created this project to practice pulling data from an API, storing that data i
 
 * Create a directory called `secret` with an empty `__init__.py` file inside. Make a `keys.py` file in the `secret` directory (based on the `secretkeys_template.py`) and populate it with your Twitter API credentials.
 
+* **If** you want to alter the default behavior, you can export any of the following environment variables:
+
+  * `NEWBIE_TWEETS_DB_URI` to override the DEFAULT_DB_URI specified in `server.py`
+
+  * `NEWBIE_TWEETS_LISTEN_HOST` to override the DEFAULT_LISTEN_HOST specified in `server.py`
+
+  * `NEWBIE_TWEETS_LISTEN_PORT` to override the DEFAULT_LISTEN_PORT specified in `server.py`
+
+
 * I still need to create a seed file for the database for others to get up and running with the project. Stay tuned! 
 
 

--- a/model.py
+++ b/model.py
@@ -19,8 +19,7 @@ class Tweet(db.Model):
         return "<Item item_id=%s handle=%s>" % (self.item_id, self.handle)
 
 
-def connect_to_db(app,
-        db_uri="postgresql://username:password@localhost:port/newb"):
+def connect_to_db(app, db_uri):
     """Connect the database to app"""
 
     app.config['SQLALCHEMY_DATABASE_URI'] = db_uri
@@ -30,12 +29,9 @@ def connect_to_db(app,
     db.init_app(app)
 
 
-
-
-
 if __name__ == "__main__":
 
-    from server import app
-    connect_to_db(app)
+    from server import app, DB_URI
+    connect_to_db(app, DB_URI)
     db.create_all()
     print("Connected to DB, Woohoo!")

--- a/server.py
+++ b/server.py
@@ -2,6 +2,7 @@ import json
 import time
 import re
 import oauth2 as oauth
+import os
 from secret import keys
 from flask import (Flask, jsonify, render_template)
 from model import (connect_to_db, db, Tweet)
@@ -16,6 +17,21 @@ app.secret_key = key['Flask_Key']
 
 link = re.compile(r'(http(s)?://\w+(\.\w+)+(/\w+)*|@(\w+)|#(\w+))')
 
+DEFAULT_DB_URI = "postgresql:///newb"
+DB_URI = os.environ.get(
+    'NEWBIE_TWEETS_DB_URI',
+    DEFAULT_DB_URI,
+)
+DEFAULT_LISTEN_HOST = '127.0.0.1:5000'
+LISTEN_HOST = os.environ.get(
+    'NEWBIE_TWEETS_LISTEN_HOST',
+    DEFAULT_LISTEN_HOST,
+)
+DEFAULT_LISTEN_PORT = '5000'
+LISTEN_PORT = int(os.environ.get(
+    'NEWBIE_TWEETS_LISTEN_PORT',
+    DEFAULT_LISTEN_PORT,
+))
 
 def authorize():
     """authorize w/ twitter api and fetch recent codenewbie tweets, return a json"""
@@ -136,7 +152,6 @@ def archives():
 
 if __name__ == "__main__":
     app.debug = True
-# Change the postgresql info below username, password, port
-    connect_to_db(app, "postgresql://username:password@localhost/newb")
-    app.run(port=5000)
+    connect_to_db(app, DB_URI)
+    app.run(host=LISTEN_HOST, port=LISTEN_PORT)
 

--- a/templates/friends.html
+++ b/templates/friends.html
@@ -41,6 +41,11 @@
                     <td>jessi.grayson@gmail.com</td>
                     <td>https://github.com/jessigrayson</td>
                 </tr> 
+                <tr>
+                    <td>Romain</td>
+                    <td></td>
+                    <td>https://github.com/rkomorn</td>
+                </tr> 
             </tbody>
         </table>
         <br>
@@ -76,6 +81,10 @@
     <div>
         <div> This gif added by <a href="https://www.linkedin.com/in/salazardenise/">Denise</a>:</div>
         <img src="http://trupanion.com/blog/wp-content/uploads/2017/09/GettyImages-512536165.jpg" alt="Corgi Puppy">
+    </div>
+    <div>
+        <div> This gif added by <a href="https://www.linkedin.com/in/romain-komorn/">Romain</a>:</div>
+        <img src="https://media.giphy.com/media/uFKHB31hX09TW/giphy.gif" alt="I<3U romaine">
     </div>
 </div>
 </div>


### PR DESCRIPTION
This (admittedly somewhat heavy-handed) PR modifies behavior to enable people who want to contribute changes to use environment variables to modify the way Flask will work (ie: host, port to listen on, DB URI to connect to).

- NEWBIE_TWEETS_DB_URI for DB URI

- NEWBIE_TWEETS_LISTEN_HOST for the host

- NEWBIE_TWEETS_LISTEN_PORT for the port

It also removes the default value for db_uri in connect_to_db which I find to be a bad idea in general (eg: people should know what they're connecting to by the time they're calling connect_to_db).

The goal is to avoid scenarios where people have to locally modify the host, port and DB URI, test their changes, then back out the spots where they modified host, port and DB URIs. Tangible examples for Hackbright grads:

- Development on vagrant requires listening on '0.0.0.0'

- Userless and passwordless connections to PostgreSQL using postgresql:///newb 

This PR also adds a funny gif to the friends template.

Tested by specifying different values for all of the above env vars.